### PR TITLE
Clear old uploads to prevent cached CSV data

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,15 @@ POSITIONS_DIR = DATA_DIR / "positions"  # positions CSVs
 UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
 POSITIONS_DIR.mkdir(parents=True, exist_ok=True)
 
+
+def _clear_csvs(folder: Path) -> None:
+    """Remove all CSV files in the given folder."""
+    for p in folder.glob("*.csv"):
+        try:
+            p.unlink()
+        except FileNotFoundError:
+            pass
+
 app = FastAPI(title="Total Return", version="1.1")
 
 app.add_middleware(
@@ -38,6 +47,7 @@ def home():
 async def upload_csv(file: UploadFile = File(...)):
     if not file.filename.lower().endswith(".csv"):
         raise HTTPException(status_code=400, detail="Upload a .csv file")
+    _clear_csvs(UPLOADS_DIR)
     dest = UPLOADS_DIR / file.filename
     with dest.open("wb") as out:
         shutil.copyfileobj(file.file, out)
@@ -47,6 +57,7 @@ async def upload_csv(file: UploadFile = File(...)):
 async def upload_positions_csv(file: UploadFile = File(...)):
     if not file.filename.lower().endswith(".csv"):
         raise HTTPException(status_code=400, detail="Upload a .csv file")
+    _clear_csvs(POSITIONS_DIR)
     dest = POSITIONS_DIR / file.filename
     with dest.open("wb") as out:
         shutil.copyfileobj(file.file, out)
@@ -106,4 +117,7 @@ def portfolio():
         "total_return_dollars": total_mv + total_divs - total_invested,
         "total_return_percent": ((total_mv + total_divs - total_invested) / total_invested * 100.0) if total_invested > 0 else None,
     }
+    # remove uploaded files to require fresh uploads next time
+    _clear_csvs(UPLOADS_DIR)
+    _clear_csvs(POSITIONS_DIR)
     return {"rows": summary, "overall": overall, "missing_prices": [s for s, p in prices.items() if p is None]}

--- a/node-app/index.js
+++ b/node-app/index.js
@@ -19,6 +19,14 @@ const app = express();
 const upload = multer({ dest: UPLOADS_DIR });
 const uploadPositions = multer({ dest: POSITIONS_DIR });
 
+function clearCsvs(folder) {
+  for (const f of fs.readdirSync(folder)) {
+    if (f.endsWith('.csv')) {
+      fs.unlinkSync(path.join(folder, f));
+    }
+  }
+}
+
 app.use('/app', express.static(path.join(ROOT, 'frontend')));
 
 app.get('/', (req, res) => {
@@ -35,6 +43,7 @@ app.post('/upload', upload.single('file'), (req, res) => {
     if (req.file) fs.unlinkSync(req.file.path);
     return res.status(400).json({ detail: 'Upload a .csv file' });
   }
+  clearCsvs(UPLOADS_DIR);
   const dest = path.join(UPLOADS_DIR, req.file.originalname);
   fs.renameSync(req.file.path, dest);
   res.json({ ok: true, filename: req.file.originalname, kind: 'activity' });
@@ -45,6 +54,7 @@ app.post('/upload_positions', uploadPositions.single('file'), (req, res) => {
     if (req.file) fs.unlinkSync(req.file.path);
     return res.status(400).json({ detail: 'Upload a .csv file' });
   }
+  clearCsvs(POSITIONS_DIR);
   const dest = path.join(POSITIONS_DIR, req.file.originalname);
   fs.renameSync(req.file.path, dest);
   res.json({ ok: true, filename: req.file.originalname, kind: 'positions' });
@@ -118,6 +128,8 @@ async function servePortfolio(req, res) {
     total_return_percent: total_invested > 0 ? (total_mv + total_divs - total_invested) / total_invested * 100 : null
   };
   const missing_prices = symbols.filter(s => prices[s] == null);
+  clearCsvs(UPLOADS_DIR);
+  clearCsvs(POSITIONS_DIR);
   res.json({ rows: summary, overall, missing_prices });
 }
 


### PR DESCRIPTION
## Summary
- remove existing CSVs before saving new uploads in Python and Node servers
- delete uploaded CSVs after portfolio calculations to require fresh uploads each time

## Testing
- `pytest`
- `npm --prefix node-app test`


------
https://chatgpt.com/codex/tasks/task_e_68b7d0e4485c8328a0ca8cbb6fdbaaa8