### PR TITLE
Clear old uploads to prevent cached CSV data

### DIFF
--- a/node-app/index.js
+++ b/node-app/index.js
@@ -19,6 +19,14 @@ const app = express();
 const upload = multer({ dest: UPLOADS_DIR });
 const uploadPositions = multer({ dest: POSITIONS_DIR });
 
+function clearCsvs(folder) {
+  for (const f of fs.readdirSync(folder)) {
+    if (f.endsWith('.csv')) {
+      fs.unlinkSync(path.join(folder, f));
+    }
+  }
+}
+
 app.use('/app', express.static(path.join(ROOT, 'frontend')));
 
 app.get('/', (req, res) => {
@@ -35,6 +43,7 @@ app.post('/upload', upload.single('file'), (req, res) => {
     if (req.file) fs.unlinkSync(req.file.path);
     return res.status(400).json({ detail: 'Upload a .csv file' });
   }
+  clearCsvs(UPLOADS_DIR);
   const dest = path.join(UPLOADS_DIR, req.file.originalname);
   fs.renameSync(req.file.path, dest);
   res.json({ ok: true, filename: req.file.originalname, kind: 'activity' });
@@ -45,6 +54,7 @@ app.post('/upload_positions', uploadPositions.single('file'), (req, res) => {
     if (req.file) fs.unlinkSync(req.file.path);
     return res.status(400).json({ detail: 'Upload a .csv file' });
   }
+  clearCsvs(POSITIONS_DIR);
   const dest = path.join(POSITIONS_DIR, req.file.originalname);
   fs.renameSync(req.file.path, dest);
   res.json({ ok: true, filename: req.file.originalname, kind: 'positions' });
@@ -79,8 +89,8 @@ function readManyCsv(folder) {
 async function servePortfolio(req, res) {
   const actRows = readManyCsv(UPLOADS_DIR);
   const posRows = readManyCsv(POSITIONS_DIR);
-  if (actRows.length === 0 && posRows.length === 0) {
-    return res.status(400).json({ detail: 'Upload an activity CSV and/or a positions CSV first' });
+  if (actRows.length === 0 || posRows.length === 0) {
+    return res.status(400).json({ detail: 'Upload both an activity CSV and a positions CSV first' });
   }
   console.log(`Computing portfolio for ${actRows.length} activity rows and ${posRows.length} position rows`);
   const summary = computePortfolioSummary(actRows, posRows);
@@ -118,6 +128,8 @@ async function servePortfolio(req, res) {
     total_return_percent: total_invested > 0 ? (total_mv + total_divs - total_invested) / total_invested * 100 : null
   };
   const missing_prices = symbols.filter(s => prices[s] == null);
+  clearCsvs(UPLOADS_DIR);
+  clearCsvs(POSITIONS_DIR);
   res.json({ rows: summary, overall, missing_prices });
 }
 


### PR DESCRIPTION
## Summary
- remove existing CSVs before saving new uploads in Python and Node servers
- delete uploaded CSVs after portfolio calculations to require fresh uploads each time
- ensure both activity and positions CSVs are present before computing the portfolio

## Testing
- `pytest`
- `npm --prefix node-app test`


------
https://chatgpt.com/codex/tasks/task_e_68b7d0e4485c8328a0ca8cbb6fdbaaa8