### PR TITLE
Add Ko-fi support link

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ cd node-app
 npm install
 npm start
 ```
+
+## Support
+
+If this project helps you, consider [supporting it on Ko-fi](https://ko-fi.com/gille).

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -99,6 +99,8 @@
     .spacer{flex:1}
     .note{margin-top:8px}
     .hidden{display:none}
+    .support{margin-top:16px;text-align:center;font-size:12px}
+    .support a{color:var(--accent);text-decoration:none}
   </style>
 </head>
 <body>
@@ -152,6 +154,10 @@
         <tbody id="rows"></tbody>
       </table>
       <div id="empty" class="note muted">Upload your CSVs, then click Recalculate.</div>
+    </div>
+
+    <div class="support muted">
+      Enjoy the tool? <a href="https://ko-fi.com/gille" target="_blank">Support it on Ko-fi</a>.
     </div>
   </div>
 

--- a/node-app/index.js
+++ b/node-app/index.js
@@ -34,7 +34,7 @@ app.get('/', (req, res) => {
   if (fs.existsSync(idx)) {
     res.sendFile(idx);
   } else {
-    res.status(500).send('<pre>Frontend missing</pre>');
+    res.status(500).send(`<pre>Frontend missing</pre><p>Support the project on <a href="https://ko-fi.com/gille" target="_blank">Ko-fi</a>.</p>`);
   }
 });
 
@@ -149,4 +149,5 @@ app.get('/recalc', wrapAsync(servePortfolio));
 const PORT = process.env.PORT || 8000;
 app.listen(PORT, () => {
   console.log(`Node Total Return server running on ${PORT}`);
+  console.log('Support the project at https://ko-fi.com/gille');
 });


### PR DESCRIPTION
## Summary
- add Ko-fi support link and styling to the web interface
- document how to support the project in the README
- show Ko-fi link from the Node server

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7e377916883289bf5a7dc1fc363e6