### PR TITLE
Handle reinvestments separately and keep uploads cumulative

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -47,7 +47,6 @@ def home():
 async def upload_csv(file: UploadFile = File(...)):
     if not file.filename.lower().endswith(".csv"):
         raise HTTPException(status_code=400, detail="Upload a .csv file")
-    _clear_csvs(UPLOADS_DIR)
     dest = UPLOADS_DIR / file.filename
     with dest.open("wb") as out:
         shutil.copyfileobj(file.file, out)
@@ -57,7 +56,6 @@ async def upload_csv(file: UploadFile = File(...)):
 async def upload_positions_csv(file: UploadFile = File(...)):
     if not file.filename.lower().endswith(".csv"):
         raise HTTPException(status_code=400, detail="Upload a .csv file")
-    _clear_csvs(POSITIONS_DIR)
     dest = POSITIONS_DIR / file.filename
     with dest.open("wb") as out:
         shutil.copyfileobj(file.file, out)
@@ -117,7 +115,4 @@ def portfolio():
         "total_return_dollars": total_mv + total_divs - total_invested,
         "total_return_percent": ((total_mv + total_divs - total_invested) / total_invested * 100.0) if total_invested > 0 else None,
     }
-    # remove uploaded files to require fresh uploads next time
-    _clear_csvs(UPLOADS_DIR)
-    _clear_csvs(POSITIONS_DIR)
     return {"rows": summary, "overall": overall, "missing_prices": [s for s, p in prices.items() if p is None]}

--- a/node-app/index.js
+++ b/node-app/index.js
@@ -43,7 +43,6 @@ app.post('/upload', upload.single('file'), (req, res) => {
     if (req.file) fs.unlinkSync(req.file.path);
     return res.status(400).json({ detail: 'Upload a .csv file' });
   }
-  clearCsvs(UPLOADS_DIR, req.file.filename);
   const dest = path.join(UPLOADS_DIR, req.file.originalname);
   fs.renameSync(req.file.path, dest);
   res.json({ ok: true, filename: req.file.originalname, kind: 'activity' });
@@ -54,7 +53,6 @@ app.post('/upload_positions', uploadPositions.single('file'), (req, res) => {
     if (req.file) fs.unlinkSync(req.file.path);
     return res.status(400).json({ detail: 'Upload a .csv file' });
   }
-  clearCsvs(POSITIONS_DIR, req.file.filename);
   const dest = path.join(POSITIONS_DIR, req.file.originalname);
   fs.renameSync(req.file.path, dest);
   res.json({ ok: true, filename: req.file.originalname, kind: 'positions' });
@@ -128,8 +126,6 @@ async function servePortfolio(req, res) {
     total_return_percent: total_invested > 0 ? (total_mv + total_divs - total_invested) / total_invested * 100 : null
   };
   const missing_prices = symbols.filter(s => prices[s] == null);
-  clearCsvs(UPLOADS_DIR);
-  clearCsvs(POSITIONS_DIR);
   res.json({ rows: summary, overall, missing_prices });
 }
 

--- a/node-app/portfolio.js
+++ b/node-app/portfolio.js
@@ -1,17 +1,24 @@
 
-const BUY_PAT = /YOU\s+BOUGHT/i;
-const SELL_PAT = /YOU\s+SOLD/i;
-const REINVEST_PAT = /REINVESTMENT/i;
-const DIV_PAT = /DIVIDEND\s+RECEIVED/i;
+// Match generic BUY/SELL verbs so that activity rows that omit the leading
+// "YOU" still count. Fidelity's CSV exports can contain plain verbs like
+// "BOUGHT" or "SOLD" which previously slipped through.
+const BUY_PAT = /(BUY|BOUGHT)/i;
+const SELL_PAT = /(SELL|SOLD)/i;
+const REINVEST_PAT = /REINVEST/i;
+const DIV_PAT = /DIVIDEND/i;
 
 const CASH_TICKERS = new Set([
   'SPAXX', 'FDRXX', 'VMFXX', 'SWVXX', 'SPRXX', 'SNVXX', 'FCASH',
   'PENDING', 'PENDING ACTIVITY', 'CASH'
 ]);
 
+function stripQuotes(x) {
+  return typeof x === 'string' ? x.replace(/^"+|"+$/g, '') : x;
+}
+
 function isCashLike(symbolRaw, desc) {
-  const s = (symbolRaw || '').trim().toUpperCase();
-  const d = (desc || '').trim().toUpperCase();
+  const s = stripQuotes(symbolRaw || '').trim().toUpperCase();
+  const d = stripQuotes(desc || '').trim().toUpperCase();
   if (!s && !d) return true;
   if (s.startsWith('SPAXX')) return true;
   if (CASH_TICKERS.has(s)) return true;
@@ -21,7 +28,7 @@ function isCashLike(symbolRaw, desc) {
 
 function normSymbol(x) {
   if (x === undefined || x === null) return null;
-  let s = String(x).trim().toUpperCase();
+  let s = stripQuotes(String(x)).trim().toUpperCase();
   if (!s || CASH_TICKERS.has(s)) return null;
   if (s.startsWith('$')) s = s.slice(1);
   return s;
@@ -33,8 +40,8 @@ const SYMBOL_IN_PARENS = /\(([A-Z][A-Z0-9\.]{0,9})\)/;
 function extractSymbol(symRaw, desc, action) {
   const norm = normSymbol(symRaw);
   if (norm) return norm;
-  const d = (desc || '').trim().toUpperCase();
-  const a = (action || '').toUpperCase();
+  const d = stripQuotes(desc || '').trim().toUpperCase();
+  const a = stripQuotes(action || '').toUpperCase();
   const paren = a.match(SYMBOL_IN_PARENS) || d.match(SYMBOL_IN_PARENS);
   if (paren) return normSymbol(paren[1]);
   const m = d.match(SYMBOL_FROM_DESC);
@@ -44,7 +51,7 @@ function extractSymbol(symRaw, desc, action) {
 
 function toNumber(val) {
   if (val === undefined || val === null) return 0;
-  let s = String(val).trim();
+  let s = stripQuotes(String(val)).trim();
   s = s.replace(/[\$,]/g, '').replace(/%/g, '');
   const m = s.match(/^\((.*)\)$/);
   if (m) s = '-' + m[1];
@@ -69,24 +76,33 @@ function aggregateActivity(rows) {
   rows = dedupe(rows);
   const out = {};
   for (const row of rows) {
-    const action = String(row['Action'] || '');
-    const symRaw = String(row['Symbol'] || '');
-    const desc = String(row['Description'] || '');
+    const action = stripQuotes(String(row['Action'] || ''));
+    const symRaw = stripQuotes(String(row['Symbol'] || ''));
+    const desc = stripQuotes(String(row['Description'] || ''));
     const sym = extractSymbol(symRaw, desc, action);
     if (!sym || isCashLike(symRaw, desc)) continue;
     const qty = toNumber(row['Quantity']);
     const amount = toNumber(row['Amount ($)'] ?? row['Amount'] ?? row['Net Amount'] ?? row['Net Amount ($)']);
-    const isBuy = BUY_PAT.test(action) || REINVEST_PAT.test(action);
+    const commission = toNumber(row['Commission ($)'] ?? row['Commission']);
+    const fees = toNumber(row['Fees ($)'] ?? row['Fees']);
+    const isBuy = BUY_PAT.test(action);
     const isSell = SELL_PAT.test(action);
-    const isDiv = DIV_PAT.test(action);
+    const isReinvest = REINVEST_PAT.test(action);
+    const isDiv = DIV_PAT.test(action) && !isReinvest;
     if (!out[sym]) out[sym] = { shares_delta: 0, net_invested_cash: 0, dividends_received: 0 };
     if (isBuy) {
+      const cash = Math.max(-amount, 0) + Math.abs(commission) + Math.abs(fees);
       out[sym].shares_delta += qty;
-      out[sym].net_invested_cash += -Math.min(amount, 0);
+      out[sym].net_invested_cash += cash;
     }
     if (isSell) {
+      const proceeds = Math.max(amount - Math.abs(commission) - Math.abs(fees), 0);
       out[sym].shares_delta -= qty;
-      out[sym].net_invested_cash -= Math.max(amount, 0);
+      out[sym].net_invested_cash -= proceeds;
+    }
+    if (isReinvest) {
+      out[sym].shares_delta += qty;
+      out[sym].dividends_received += Math.max(-amount, 0);
     }
     if (isDiv) {
       out[sym].dividends_received += Math.max(amount, 0);
@@ -99,8 +115,8 @@ function parsePositions(rows) {
   rows = dedupe(rows);
   const out = {};
   for (const row of rows) {
-    const symRaw = String(row['Symbol'] || '');
-    const desc = String(row['Description'] || '');
+    const symRaw = stripQuotes(String(row['Symbol'] || ''));
+    const desc = stripQuotes(String(row['Description'] || ''));
     const sym = extractSymbol(symRaw, desc);
     if (!sym || isCashLike(symRaw, desc)) continue;
     const qty = toNumber(row['Quantity']);


### PR DESCRIPTION
## Summary
- Treat reinvestments as dividend-funded purchases so they no longer inflate external cash invested and broaden dividend detection
- Include commissions and fees in buy/sell cashflow calculations
- Preserve previously uploaded CSVs in both Python and Node servers to support multi-file aggregation

## Testing
- `pytest`
- `cd node-app && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7ee14cf9c8328bc1086f7db2dc132